### PR TITLE
Update pyyaml to 5.1 due to security issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 requests==2.20.0
 python-dateutil==2.3
-pyyaml==3.11
+pyyaml==5.1


### PR DESCRIPTION
GitHub keeps warning about a security issue.  I'd like that to go away by either us dismissing the vulnerability or fixing the vulnerability.  [Alert Link](https://github.com/rstudio/influxdb_backup/network/alert/requirements.txt/pyyaml/open)


https://nvd.nist.gov/vuln/detail/CVE-2017-18342
> In PyYAML before 4.1, the yaml.load() API could execute arbitrary code. In other words, yaml.safe_load is not used.

I do not know the implications to this project by changing `pyyaml` from v3.11 to v5.1.

https://github.com/yaml/pyyaml/blob/master/CHANGES

cc @cbarraford 